### PR TITLE
Midi USB support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ set(MEGATOY_SOURCES
   src/preference_manager.cpp
   src/channel_allocator.cpp
   src/resource_manager.cpp
+  src/midi_usb.cpp
   src/patches/patch_repository.cpp
   src/platform/file_dialog.cpp
   src/parsers/ctrmml_parser.cpp
@@ -163,6 +164,27 @@ if(CMAKE_BUILD_TYPE STREQUAL "Release")
           -O3 -ffast-math -funroll-loops -march=native>
         $<$<CXX_COMPILER_ID:MSVC>:/O2 /fp:fast>
     )
+endif()
+
+# RtMidi installed via Homebrew
+if(APPLE)
+  # Find the directory containing RtMidi.h
+  execute_process(
+    COMMAND find /opt/homebrew/Cellar/rtmidi -name RtMidi.h
+    OUTPUT_VARIABLE RTMIDI_HEADER_PATH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+
+  # Extract the directory path from the full header file path
+  get_filename_component(RTMIDI_INCLUDE_DIR "${RTMIDI_HEADER_PATH}" DIRECTORY)
+
+  message(STATUS "RtMidi header found at: ${RTMIDI_HEADER_PATH}")
+  message(STATUS "RtMidi include dir set to: ${RTMIDI_INCLUDE_DIR}")
+
+  # Add the include path and link settings
+  target_include_directories(megatoy PRIVATE ${RTMIDI_INCLUDE_DIR})
+  target_link_directories(megatoy PRIVATE /opt/homebrew/lib)
+  target_link_libraries(megatoy PRIVATE rtmidi)
 endif()
 
 target_link_libraries(megatoy PRIVATE

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "ui/preferences.hpp"
 #include "ym2612/channel.hpp"
 #include <iostream>
+#include "midi_usb.hpp"
 
 int main(int argc, char *argv[]) {
   std::cout << "VGM Real-time Audio Test with Dear ImGui\n";
@@ -20,6 +21,10 @@ int main(int argc, char *argv[]) {
       .channel(ym2612::ChannelIndex::Fm1)
       .write_frequency({4, Key::C});
 
+  // Init MIDI
+  MidiInputManager midi;
+  midi.init();
+
   std::cout
       << "GUI initialized. Use the button in the window to play C4 note.\n";
 
@@ -29,6 +34,9 @@ int main(int argc, char *argv[]) {
     app_state.gui_manager().poll_events();
     // Start new frame
     app_state.gui_manager().begin_frame();
+
+    // Midi USB update
+    midi.poll(app_state);
 
     ui::render_main_menu(app_state);
     // Render UI panels

--- a/src/midi_usb.cpp
+++ b/src/midi_usb.cpp
@@ -1,0 +1,92 @@
+// midi.cpp
+#include "midi.hpp"
+#include <RtMidi.h>
+#include <iostream>
+#include <mutex>
+#include <vector>
+
+struct MidiInputManager::Impl {
+  std::unique_ptr<RtMidiIn> midi_in;
+  std::vector<unsigned char> message;
+  std::mutex message_mutex;
+
+  bool init() {
+    try {
+      midi_in = std::make_unique<RtMidiIn>();
+
+      unsigned int ports = midi_in->getPortCount();
+      if (ports == 0) {
+        std::cout << "No MIDI input ports found.\n";
+        return false;
+      }
+
+      std::cout << "Opening MIDI input port 0: "
+                << midi_in->getPortName(0) << "\n";
+
+      midi_in->openPort(0);
+      midi_in->ignoreTypes(false, false, false);
+      return true;
+    } catch (RtMidiError &error) {
+      std::cerr << "RtMidi error: " << error.getMessage() << "\n";
+      return false;
+    }
+  }
+
+  void poll(AppState &app_state) {
+    if (!midi_in)
+      return;
+
+    double stamp;
+    message.clear();
+
+    stamp = midi_in->getMessage(&message);
+    if (message.empty())
+      return;
+
+    unsigned char status = message[0];
+    if ((status & 0xF0) == 0x90 && message[2] > 0) {
+      // Note On
+      int note = message[1];
+      int velocity = message[2];
+      std::cout << "Note ON: " << note << " vel: " << velocity << "\n";
+
+      // Example: Play note on FM1
+      auto key = static_cast<Key>(note % 12);
+      int octave = (note / 12) - 1;
+      app_state.device()
+          .channel(ym2612::ChannelIndex::Fm1)
+          .write_frequency({octave, key});
+      app_state.device()
+          .channel(ym2612::ChannelIndex::Fm1)
+          .key_on(true);
+    } else if ((status & 0xF0) == 0x80 || (status & 0xF0) == 0x90) {
+      // Note Off
+      int note = message[1];
+      std::cout << "Note OFF: " << note << "\n";
+      app_state.device()
+          .channel(ym2612::ChannelIndex::Fm1)
+          .key_on(false);
+    }
+  }
+
+  void shutdown() {
+    if (midi_in && midi_in->isPortOpen()) {
+      midi_in->closePort();
+    }
+  }
+};
+
+MidiInputManager::MidiInputManager() : impl_(std::make_unique<Impl>()) {}
+MidiInputManager::~MidiInputManager() { impl_->shutdown(); }
+
+bool MidiInputManager::init() {
+  return impl_->init();
+}
+
+void MidiInputManager::shutdown() {
+  impl_->shutdown();
+}
+
+void MidiInputManager::poll(AppState &app_state) {
+  impl_->poll(app_state);
+}

--- a/src/midi_usb.hpp
+++ b/src/midi_usb.hpp
@@ -1,0 +1,20 @@
+// midi_usb.hpp
+#pragma once
+
+#include "app_state.hpp"
+#include <memory>
+
+class MidiInputManager {
+public:
+  MidiInputManager();
+  ~MidiInputManager();
+
+  bool init();
+  void shutdown();
+
+  void poll(AppState &app_state);  // Call each frame
+
+private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};


### PR DESCRIPTION
this will add support for any Midi USB device.

EDIT: i found your channel_allocator and used it to support polyphony so chords can be played :)

REQUIRES:
https://formulae.brew.sh/formula/rtmidi
`brew install rtmidi`

i tried to make this not interfere with everything else you built

:)

https://github.com/user-attachments/assets/ee026d6e-3584-4b86-bf7a-636df87aef42

