### PR TITLE
Add a generic history manager and unify patch editor undo/redo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,7 @@ set(MEGATOY_SOURCES
   src/preference_manager.cpp
   src/channel_allocator.cpp
   src/resource_manager.cpp
+  src/history/history_manager.cpp
   src/midi_usb.cpp
   src/patches/patch_repository.cpp
   src/platform/file_dialog.cpp

--- a/src/app_state.cpp
+++ b/src/app_state.cpp
@@ -12,7 +12,7 @@ AppState::PatchState::PatchState(const std::filesystem::path &preset_dir,
 
 AppState::AppState()
     : device_(), audio_manager_(), gui_manager_(), preference_manager_(),
-      channel_allocator_(), input_state_(), ui_state_(),
+      channel_allocator_(), input_state_(), ui_state_(), history_(),
       patch_state_(preference_manager_.get_patches_directory(),
                    preference_manager_.get_user_patches_directory()) {
   const auto &ui_prefs = preference_manager_.ui_preferences();
@@ -29,6 +29,7 @@ void AppState::init() {
 
   initialize_patch_defaults();
   apply_patch_to_device();
+  history_.reset();
 
   configure_audio();
   configure_gui();
@@ -94,6 +95,7 @@ bool AppState::load_patch(const patches::PatchEntry &patch_info) {
   patch_state_.current = loaded_patch;
   patch_state_.current_patch_path = patch_info.relative_path;
   apply_patch_to_device();
+  history_.reset();
   std::cout << "Loaded preset patch: " << patch_info.name << std::endl;
   return true;
 }

--- a/src/app_state.hpp
+++ b/src/app_state.hpp
@@ -3,6 +3,7 @@
 #include "audio_manager.hpp"
 #include "channel_allocator.hpp"
 #include "gui_manager.hpp"
+#include "history/history_manager.hpp"
 #include "patches/patch_repository.hpp"
 #include "preference_manager.hpp"
 #include "types.hpp"
@@ -74,7 +75,11 @@ public:
   patches::PatchRepository &patch_repository();
   const patches::PatchRepository &patch_repository() const;
 
+  history::HistoryManager &history() { return history_; }
+  const history::HistoryManager &history() const { return history_; }
+
   void update_all_settings();
+  void apply_patch_to_device();
 
   bool key_on(ym2612::Note note);
   bool key_off(ym2612::Note note);
@@ -101,6 +106,7 @@ private:
   ChannelAllocator channel_allocator_;
   InputState input_state_;
   UIState ui_state_;
+  history::HistoryManager history_;
 
   struct PatchState {
     ym2612::Patch current;
@@ -115,5 +121,4 @@ private:
   void configure_audio();
   void configure_gui();
   void configure_audio_callback();
-  void apply_patch_to_device();
 };

--- a/src/history/history_entry.hpp
+++ b/src/history/history_entry.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string_view>
+
+class AppState;
+
+namespace history {
+
+class HistoryEntry {
+public:
+  virtual ~HistoryEntry() = default;
+
+  virtual void undo(AppState &app_state) = 0;
+  virtual void redo(AppState &app_state) = 0;
+
+  virtual std::string_view label() const = 0;
+  virtual std::string_view merge_key() const = 0;
+
+  virtual bool try_merge(const HistoryEntry &next) { return false; }
+};
+
+} // namespace history

--- a/src/history/history_manager.cpp
+++ b/src/history/history_manager.cpp
@@ -1,0 +1,111 @@
+#include "history_manager.hpp"
+
+#include "../app_state.hpp"
+#include "history_entry.hpp"
+#include <utility>
+
+namespace history {
+
+HistoryManager::HistoryManager(std::size_t max_entries)
+    : max_entries_(max_entries ? max_entries : 1), undo_stack_(), redo_stack_(),
+      active_transaction_() {}
+
+void HistoryManager::clear() {
+  undo_stack_.clear();
+  redo_stack_.clear();
+  active_transaction_.reset();
+}
+
+void HistoryManager::reset() { clear(); }
+
+bool HistoryManager::can_undo() const { return !undo_stack_.empty(); }
+
+bool HistoryManager::can_redo() const { return !redo_stack_.empty(); }
+
+std::string_view HistoryManager::undo_label() const {
+  return can_undo() ? undo_stack_.back()->label() : std::string_view{};
+}
+
+std::string_view HistoryManager::redo_label() const {
+  return can_redo() ? redo_stack_.back()->label() : std::string_view{};
+}
+
+void HistoryManager::undo(AppState &app_state) {
+  if (!can_undo()) {
+    return;
+  }
+
+  cancel_transaction();
+
+  auto entry = std::move(undo_stack_.back());
+  undo_stack_.pop_back();
+  entry->undo(app_state);
+  redo_stack_.push_back(std::move(entry));
+}
+
+void HistoryManager::redo(AppState &app_state) {
+  if (!can_redo()) {
+    return;
+  }
+
+  cancel_transaction();
+
+  auto entry = std::move(redo_stack_.back());
+  redo_stack_.pop_back();
+  entry->redo(app_state);
+  undo_stack_.push_back(std::move(entry));
+}
+
+void HistoryManager::begin_transaction(std::string label, std::string merge_key,
+                                       EntryFactory factory) {
+  cancel_transaction();
+  active_transaction_.emplace(ActiveTransaction{
+      .label = std::move(label),
+      .merge_key = std::move(merge_key),
+      .factory = std::move(factory),
+  });
+}
+
+void HistoryManager::commit_transaction(AppState &app_state) {
+  if (!active_transaction_) {
+    return;
+  }
+
+  auto factory = std::move(active_transaction_->factory);
+  active_transaction_.reset();
+  if (!factory) {
+    return;
+  }
+
+  auto entry = factory(app_state);
+  if (!entry) {
+    return;
+  }
+
+  push_entry(std::move(entry));
+}
+
+void HistoryManager::cancel_transaction() { active_transaction_.reset(); }
+
+void HistoryManager::push_entry(std::unique_ptr<HistoryEntry> entry) {
+  if (!undo_stack_.empty() && !entry->merge_key().empty()) {
+    if (undo_stack_.back()->merge_key() == entry->merge_key()) {
+      if (undo_stack_.back()->try_merge(*entry)) {
+        redo_stack_.clear();
+        return;
+      }
+    }
+  }
+
+  undo_stack_.push_back(std::move(entry));
+  redo_stack_.clear();
+  trim_to_max();
+}
+
+void HistoryManager::trim_to_max() {
+  while (undo_stack_.size() > max_entries_) {
+    undo_stack_.erase(undo_stack_.begin());
+  }
+}
+
+} // namespace history

--- a/src/history/history_manager.hpp
+++ b/src/history/history_manager.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "history_entry.hpp"
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+class AppState;
+
+namespace history {
+
+class HistoryManager {
+public:
+  explicit HistoryManager(std::size_t max_entries = 256);
+
+  void clear();
+  void reset();
+
+  bool can_undo() const;
+  bool can_redo() const;
+
+  std::string_view undo_label() const;
+  std::string_view redo_label() const;
+
+  void undo(AppState &app_state);
+  void redo(AppState &app_state);
+
+  using EntryFactory = std::function<std::unique_ptr<HistoryEntry>(AppState &)>;
+
+  void begin_transaction(std::string label, std::string merge_key,
+                         EntryFactory factory);
+  void commit_transaction(AppState &app_state);
+  void cancel_transaction();
+
+private:
+  void push_entry(std::unique_ptr<HistoryEntry> entry);
+  void trim_to_max();
+
+  std::size_t max_entries_;
+  std::vector<std::unique_ptr<HistoryEntry>> undo_stack_;
+  std::vector<std::unique_ptr<HistoryEntry>> redo_stack_;
+
+  struct ActiveTransaction {
+    std::string label;
+    std::string merge_key;
+    EntryFactory factory;
+  };
+
+  std::optional<ActiveTransaction> active_transaction_;
+};
+
+} // namespace history

--- a/src/history/snapshot_entry.hpp
+++ b/src/history/snapshot_entry.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "history_entry.hpp"
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+
+class AppState;
+
+namespace history {
+
+template <typename Value> class SnapshotEntry : public HistoryEntry {
+public:
+  using ApplyFn = std::function<void(AppState &, const Value &)>;
+
+  SnapshotEntry(std::string label, std::string merge_key, Value before,
+                Value after, ApplyFn apply)
+      : label_(std::move(label)), merge_key_(std::move(merge_key)),
+        before_(std::move(before)), after_(std::move(after)),
+        apply_(std::move(apply)) {}
+
+  void undo(AppState &app_state) override { apply_(app_state, before_); }
+
+  void redo(AppState &app_state) override { apply_(app_state, after_); }
+
+  std::string_view label() const override { return label_; }
+  std::string_view merge_key() const override { return merge_key_; }
+
+  bool try_merge(const HistoryEntry &next) override {
+    if (merge_key_.empty()) {
+      return false;
+    }
+    const auto *other = dynamic_cast<const SnapshotEntry *>(&next);
+    if (!other) {
+      return false;
+    }
+    if (other->merge_key_ != merge_key_) {
+      return false;
+    }
+    after_ = other->after_;
+    label_ = other->label_;
+    return true;
+  }
+
+private:
+  std::string label_;
+  std::string merge_key_;
+  Value before_;
+  Value after_;
+  ApplyFn apply_;
+};
+
+template <typename Value>
+std::unique_ptr<HistoryEntry>
+make_snapshot_entry(std::string label, std::string merge_key, Value before,
+                    Value after, typename SnapshotEntry<Value>::ApplyFn apply) {
+  if (before == after) {
+    return nullptr;
+  }
+
+  return std::make_unique<SnapshotEntry<Value>>(
+      std::move(label), std::move(merge_key), std::move(before),
+      std::move(after), std::move(apply));
+}
+
+} // namespace history

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "ui/patch_selector.hpp"
 #include "ui/preferences.hpp"
 #include "ym2612/channel.hpp"
+#include <imgui.h>
 #include <iostream>
 
 namespace {
@@ -21,6 +22,36 @@ PreferenceManager::UIPreferences make_ui_preferences(const UIState &ui_state) {
   prefs.show_preferences = ui_state.show_preferences;
   prefs.patch_search_query = ui_state.patch_search_query;
   return prefs;
+}
+
+void handle_history_shortcuts(AppState &app_state) {
+  ImGuiIO &io = ImGui::GetIO();
+
+  if (io.WantTextInput || app_state.input_state().text_input_focused) {
+    return;
+  }
+
+  const bool primary_modifier = io.KeyCtrl || io.KeySuper;
+  if (!primary_modifier) {
+    return;
+  }
+
+  const bool shift = io.KeyShift;
+  auto &history = app_state.history();
+
+  if (ImGui::IsKeyPressed(ImGuiKey_Z, false)) {
+    if (shift) {
+      if (history.can_redo()) {
+        history.redo(app_state);
+      }
+    } else if (history.can_undo()) {
+      history.undo(app_state);
+    }
+  } else if (ImGui::IsKeyPressed(ImGuiKey_Y, false)) {
+    if (history.can_redo()) {
+      history.redo(app_state);
+    }
+  }
 }
 
 } // namespace
@@ -56,6 +87,7 @@ int main(int argc, char *argv[]) {
     // ImGui::ShowDemoWindow();
 
     ui::render_main_menu(app_state);
+    handle_history_shortcuts(app_state);
     // Render UI panels
     ui::render_patch_editor(app_state);
 

--- a/src/ui/history_helpers.hpp
+++ b/src/ui/history_helpers.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "../app_state.hpp"
+#include "../history/snapshot_entry.hpp"
+#include <imgui.h>
+#include <string>
+
+namespace ui {
+
+inline void track_patch_history(AppState &app_state, const std::string &label,
+                                const std::string &merge_key = {}) {
+  const std::string key = merge_key.empty() ? label : merge_key;
+  if (ImGui::IsItemActivated()) {
+    auto before = app_state.patch();
+    std::string label_copy = label;
+    std::string key_copy = key;
+
+    app_state.history().begin_transaction(
+        label_copy, key_copy,
+        [label = std::move(label_copy), key = std::move(key_copy),
+         before = std::move(before)](AppState &state) mutable {
+          auto entry = history::make_snapshot_entry<ym2612::Patch>(
+              label, key, before, state.patch(),
+              [](AppState &target, const ym2612::Patch &value) {
+                target.patch() = value;
+                target.apply_patch_to_device();
+              });
+          return entry;
+        });
+  }
+  if (ImGui::IsItemDeactivatedAfterEdit()) {
+    app_state.history().commit_transaction(app_state);
+  }
+}
+
+inline void track_patch_history(AppState &app_state, const char *label,
+                                const char *merge_key = nullptr) {
+  const std::string key = (merge_key && merge_key[0]) ? merge_key : label;
+  track_patch_history(app_state, std::string(label), key);
+}
+
+} // namespace ui

--- a/src/ui/main_menu.cpp
+++ b/src/ui/main_menu.cpp
@@ -2,11 +2,51 @@
 
 #include "../gui_manager.hpp"
 #include <imgui.h>
+#include <string>
+#include <string_view>
 
 namespace ui {
 
 void render_main_menu(AppState &app_state) {
   if (ImGui::BeginMainMenuBar()) {
+    if (ImGui::BeginMenu("Edit")) {
+      auto &history = app_state.history();
+      const ImGuiIO &io = ImGui::GetIO();
+      const bool mac_behavior = io.ConfigMacOSXBehaviors;
+      const char *undo_shortcut = mac_behavior ? "Cmd+Z" : "Ctrl+Z";
+      const char *redo_shortcut = mac_behavior ? "Cmd+Shift+Z" : "Ctrl+Shift+Z";
+
+      std::string undo_label = "Undo";
+      if (history.can_undo()) {
+        std::string_view change = history.undo_label();
+        if (!change.empty()) {
+          undo_label.append(" ");
+          undo_label.append(change);
+        }
+      }
+
+      if (ImGui::MenuItem(undo_label.c_str(), undo_shortcut, false,
+                          history.can_undo())) {
+        history.undo(app_state);
+      }
+
+      std::string redo_label = "Redo";
+      if (history.can_redo()) {
+        std::string_view change = history.redo_label();
+        if (!change.empty()) {
+          redo_label.append(" ");
+          redo_label.append(change);
+        }
+      }
+
+      if (ImGui::MenuItem(redo_label.c_str(), redo_shortcut, false,
+                          history.can_redo())) {
+        history.redo(app_state);
+      }
+
+      ImGui::EndMenu();
+    }
+
     if (ImGui::BeginMenu("View")) {
       auto &ui_state = app_state.ui_state();
 

--- a/src/ui/operator_editor.cpp
+++ b/src/ui/operator_editor.cpp
@@ -1,25 +1,34 @@
 #include "operator_editor.hpp"
+#include "history_helpers.hpp"
 #include "preview/ssg_preview.hpp"
-#include <cstring>
 #include <imgui.h>
 #include <string>
 
 namespace ui {
 
 // Helper function to render operator settings
-void render_operator_editor(ym2612::OperatorSettings &op, int op_num) {
+void render_operator_editor(AppState &app_state, ym2612::OperatorSettings &op,
+                            int op_num) {
   std::string op_label = "Operator " + std::to_string(op_num);
+  std::string key_prefix = "instrument.op" + std::to_string(op_num);
   ImGui::SeparatorText(op_label.c_str());
   ImGui::PushID(op_num);
   ImGui::PushItemWidth(150);
 
   // Amplitude Modulation Enable
-  ImGui::Checkbox("Amplitude Modulation Enable",
-                  &op.amplitude_modulation_enable);
+  bool amplitude_mod = op.amplitude_modulation_enable;
+  if (ImGui::Checkbox("Amplitude Modulation Enable", &amplitude_mod)) {
+    op.amplitude_modulation_enable = amplitude_mod;
+  }
+  track_patch_history(app_state, op_label + " Amplitude Modulation",
+                      key_prefix + ".am_enable");
 
   // Total Level (0-127)
   int total_level = op.total_level;
-  if (ImGui::SliderInt("Total Level", &total_level, 127, 0)) {
+  bool total_changed = ImGui::SliderInt("Total Level", &total_level, 127, 0);
+  track_patch_history(app_state, op_label + " Total Level",
+                      key_prefix + ".total_level");
+  if (total_changed) {
     op.total_level = static_cast<uint8_t>(total_level);
   }
 
@@ -27,31 +36,48 @@ void render_operator_editor(ym2612::OperatorSettings &op, int op_num) {
 
   // Attack Rate (0-31)
   int attack_rate = op.attack_rate;
-  if (ImGui::SliderInt("Attack Rate", &attack_rate, 0, 31)) {
+  bool attack_changed = ImGui::SliderInt("Attack Rate", &attack_rate, 0, 31);
+  track_patch_history(app_state, op_label + " Attack Rate",
+                      key_prefix + ".attack_rate");
+  if (attack_changed) {
     op.attack_rate = static_cast<uint8_t>(attack_rate);
   }
 
   // Decay Rate (0-31)
   int decay_rate = op.decay_rate;
-  if (ImGui::SliderInt("Decay Rate", &decay_rate, 0, 31)) {
+  bool decay_changed = ImGui::SliderInt("Decay Rate", &decay_rate, 0, 31);
+  track_patch_history(app_state, op_label + " Decay Rate",
+                      key_prefix + ".decay_rate");
+  if (decay_changed) {
     op.decay_rate = static_cast<uint8_t>(decay_rate);
   }
 
   // Sustain Level (0-15)
   int sustain_level = op.sustain_level;
-  if (ImGui::SliderInt("Sustain Level", &sustain_level, 15, 0)) {
+  bool sustain_level_changed =
+      ImGui::SliderInt("Sustain Level", &sustain_level, 15, 0);
+  track_patch_history(app_state, op_label + " Sustain Level",
+                      key_prefix + ".sustain_level");
+  if (sustain_level_changed) {
     op.sustain_level = static_cast<uint8_t>(sustain_level);
   }
 
   // Sustain Rate (0-31)
   int sustain_rate = op.sustain_rate;
-  if (ImGui::SliderInt("Sustain Rate", &sustain_rate, 0, 31)) {
+  bool sustain_rate_changed =
+      ImGui::SliderInt("Sustain Rate", &sustain_rate, 0, 31);
+  track_patch_history(app_state, op_label + " Sustain Rate",
+                      key_prefix + ".sustain_rate");
+  if (sustain_rate_changed) {
     op.sustain_rate = static_cast<uint8_t>(sustain_rate);
   }
 
   // Release Rate (0-15)
   int release_rate = op.release_rate;
-  if (ImGui::SliderInt("Release Rate", &release_rate, 0, 15)) {
+  bool release_changed = ImGui::SliderInt("Release Rate", &release_rate, 15, 0);
+  track_patch_history(app_state, op_label + " Release Rate",
+                      key_prefix + ".release_rate");
+  if (release_changed) {
     op.release_rate = static_cast<uint8_t>(release_rate);
   }
 
@@ -59,22 +85,31 @@ void render_operator_editor(ym2612::OperatorSettings &op, int op_num) {
 
   // Key Scale (0-3)
   int key_scale = op.key_scale;
-  if (ImGui::SliderInt("Key Scale", &key_scale, 0, 3)) {
+  bool key_scale_changed = ImGui::SliderInt("Key Scale", &key_scale, 0, 3);
+  track_patch_history(app_state, op_label + " Key Scale",
+                      key_prefix + ".key_scale");
+  if (key_scale_changed) {
     op.key_scale = static_cast<uint8_t>(key_scale);
   }
 
   // Multiple (0-15)
   int multiple = op.multiple;
-  if (ImGui::SliderInt("Multiple", &multiple, 0, 15)) {
+  bool multiple_changed = ImGui::SliderInt("Multiple", &multiple, 0, 15);
+  track_patch_history(app_state, op_label + " Multiple",
+                      key_prefix + ".multiple");
+  if (multiple_changed) {
     op.multiple = static_cast<uint8_t>(multiple);
   }
 
   // Detune (0-7)
-  int detune = op.detune;
   static const char *labels[] = {
       "0", "+1", "+2", "+3", "0", "-1", "-2", "-3",
   };
-  if (ImGui::SliderInt("Detune", &detune, 0, 7, labels[detune])) {
+  int detune = op.detune;
+  bool detune_changed =
+      ImGui::SliderInt("Detune", &detune, 0, 7, labels[detune]);
+  track_patch_history(app_state, op_label + " Detune", key_prefix + ".detune");
+  if (detune_changed) {
     op.detune = static_cast<uint8_t>(detune);
   }
 
@@ -90,9 +125,17 @@ void render_operator_editor(ym2612::OperatorSettings &op, int op_num) {
   }
   ImGui::SameLine();
 
-  ImGui::Checkbox("SSG Enable", &op.ssg_enable);
+  bool ssg_enable = op.ssg_enable;
+  if (ImGui::Checkbox("SSG Enable", &ssg_enable)) {
+    op.ssg_enable = ssg_enable;
+  }
+  track_patch_history(app_state, op_label + " SSG Enable",
+                      key_prefix + ".ssg_enable");
 
-  if (ImGui::SliderInt("SSG Type", &ssg_type, 0, 7)) {
+  bool ssg_type_changed = ImGui::SliderInt("SSG Type", &ssg_type, 0, 7);
+  track_patch_history(app_state, op_label + " SSG Type",
+                      key_prefix + ".ssg_type");
+  if (ssg_type_changed) {
     op.ssg_type_envelope_control = static_cast<uint8_t>(ssg_type);
   }
   ImGui::PopItemWidth();

--- a/src/ui/operator_editor.hpp
+++ b/src/ui/operator_editor.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
+#include "../app_state.hpp"
 #include "../ym2612/types.hpp"
 #include <imgui.h>
 
 namespace ui {
 // Helper function to render operator settings
-void render_operator_editor(ym2612::OperatorSettings &op, int op_num);
+void render_operator_editor(AppState &app_state, ym2612::OperatorSettings &op,
+                            int op_num);
 } // namespace ui

--- a/src/ym2612/patch.hpp
+++ b/src/ym2612/patch.hpp
@@ -1,5 +1,7 @@
 #pragma once
 #include "types.hpp"
+#include <algorithm>
+#include <iterator>
 #include <nlohmann/json.hpp>
 #include <string>
 
@@ -13,6 +15,69 @@ struct Patch {
   ChannelSettings channel;
   ChannelInstrument instrument;
 };
+
+inline bool operator==(const GlobalSettings &lhs, const GlobalSettings &rhs) {
+  return lhs.dac_enable == rhs.dac_enable && lhs.lfo_enable == rhs.lfo_enable &&
+         lhs.lfo_frequency == rhs.lfo_frequency;
+}
+
+inline bool operator!=(const GlobalSettings &lhs, const GlobalSettings &rhs) {
+  return !(lhs == rhs);
+}
+
+inline bool operator==(const OperatorSettings &lhs,
+                       const OperatorSettings &rhs) {
+  return lhs.attack_rate == rhs.attack_rate &&
+         lhs.decay_rate == rhs.decay_rate &&
+         lhs.sustain_rate == rhs.sustain_rate &&
+         lhs.release_rate == rhs.release_rate &&
+         lhs.sustain_level == rhs.sustain_level &&
+         lhs.total_level == rhs.total_level && lhs.key_scale == rhs.key_scale &&
+         lhs.multiple == rhs.multiple && lhs.detune == rhs.detune &&
+         lhs.ssg_type_envelope_control == rhs.ssg_type_envelope_control &&
+         lhs.ssg_enable == rhs.ssg_enable &&
+         lhs.amplitude_modulation_enable == rhs.amplitude_modulation_enable;
+}
+
+inline bool operator!=(const OperatorSettings &lhs,
+                       const OperatorSettings &rhs) {
+  return !(lhs == rhs);
+}
+
+inline bool operator==(const ChannelSettings &lhs, const ChannelSettings &rhs) {
+  return lhs.left_speaker == rhs.left_speaker &&
+         lhs.right_speaker == rhs.right_speaker &&
+         lhs.amplitude_modulation_sensitivity ==
+             rhs.amplitude_modulation_sensitivity &&
+         lhs.frequency_modulation_sensitivity ==
+             rhs.frequency_modulation_sensitivity;
+}
+
+inline bool operator!=(const ChannelSettings &lhs, const ChannelSettings &rhs) {
+  return !(lhs == rhs);
+}
+
+inline bool operator==(const ChannelInstrument &lhs,
+                       const ChannelInstrument &rhs) {
+  return lhs.feedback == rhs.feedback && lhs.algorithm == rhs.algorithm &&
+         std::equal(std::begin(lhs.operators), std::end(lhs.operators),
+                    std::begin(rhs.operators), std::end(rhs.operators));
+}
+
+inline bool operator!=(const ChannelInstrument &lhs,
+                       const ChannelInstrument &rhs) {
+  return !(lhs == rhs);
+}
+
+inline bool operator==(const Patch &lhs, const Patch &rhs) {
+  return lhs.name == rhs.name && lhs.category == rhs.category &&
+         lhs.global == rhs.global && lhs.channel == rhs.channel &&
+         lhs.instrument == rhs.instrument;
+}
+
+inline bool operator!=(const Patch &lhs, const Patch &rhs) {
+  return !(lhs == rhs);
+}
 
 // JSON serialization helpers
 inline void to_json(nlohmann::json &j, const GlobalSettings &device) {


### PR DESCRIPTION
- Added a transaction-driven HistoryManager.
- Introduced history::SnapshotEntry<T> to capture arbitrary before/after values and reapply them, including YM2612 patch propagation to the device.
- Hooked patch and operator editor widgets into the new API so every slider/checkbox interaction produces an undoable history entry.
- Normalized history resets during app startup and preset loading to keep the stack consistent across patch changes.